### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@
 > [📖 Read the documentation](https://nuxt-kql.byjohann.dev)
 
 ```bash
-# pnpm
-pnpm add -D nuxt-kql
-
-# npm
-npm i -D nuxt-kql
+npx nuxi@latest module add kql
 ```
 
 ## Basic Usage

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,14 +8,6 @@ Choose your favorite from the [starter kits](/guide/starters) page and get start
 
 ## Step 1: Install `nuxt-kql`
 
-Using [pnpm](https://pnpm.io):
-
-```bash
-$ npx nuxi@latest module add kql
-```
-
-Using npm:
-
 ```bash
 $ npx nuxi@latest module add kql
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,13 +11,13 @@ Choose your favorite from the [starter kits](/guide/starters) page and get start
 Using [pnpm](https://pnpm.io):
 
 ```bash
-$ pnpm add -D nuxt-kql
+$ npx nuxi@latest module add kql
 ```
 
 Using npm:
 
 ```bash
-$ npm i -D nuxt-kql
+$ npx nuxi@latest module add kql
 ```
 
 ## Step 2: Add `nuxt-kql` to Nuxt


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description



This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
